### PR TITLE
Update Python and Javascript hours formats to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ class DemoForm(forms.Form):
     # DateTime Range Fields
     datetime_range_normal = fields.DateTimeRangeField()
     datetime_range_with_format = fields.DateTimeRangeField(
-        input_formats=['%d/%m/%Y (%H:%M:%S)'],
+        input_formats=['%d/%m/%Y (%I:%M:%S)'],
         widget=widgets.DateTimeRangeWidget(
-            format='%d/%m/%Y (%H:%M:%S)'
+            format='%d/%m/%Y (%I:%M:%S)'
         )
     )
     datetime_range_clearable = fields.DateTimeRangeField(clearable=True)

--- a/bootstrap_daterangepicker/widgets.py
+++ b/bootstrap_daterangepicker/widgets.py
@@ -20,8 +20,8 @@ format_to_js = {
     '%B': 'MMMM',
     '%b': 'MMM',
     '%M': 'mm',
-    '%H': 'hh',
-    '%I': 'h',
+    '%H': 'HH',
+    '%I': 'hh',
     '%p': 'A',
     '%S': 'ss',
 }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if 'upload' in sys.argv or 'register' in sys.argv:
 
 setup(
     name='django-bootstrap-daterangepicker',
-    version='1.0.1',
+    version='1.0.2',
 
     description='A Django form field and widget wrapper for bootstrap-daterangepicker',
     long_description=long_description,


### PR DESCRIPTION
Changed lines 23 and 24 in widgets.py to the following:

    '%H': 'hh',
    '%I': 'h',
to

    '%H': 'HH',
    '%I': 'hh',

Both %H and HH represent zero-padded 24-hour hours, so one should be equivalent to the other. h represents non-padded 12-hour hours, and is probably not useful with this widget. %I and hh are both zero-padded 12-hour hours, and should be considered equivalent as well.

In the current code, if "picker_options={'timePicker24Hour': True,}" is passed to the DateTimepicker, and %H is used in the format string, the widget popup will display 24-hour hours, but will send 12-hour hours to the CharField in the form. For instance, the user can actually select 1930 or 2300 as valid times in the popup, but 0730 and 1100 will result in the text of the CharField.