### PR TITLE
string_concat was deprecated so use format_lazy

### DIFF
--- a/bootstrap_daterangepicker/fields.py
+++ b/bootstrap_daterangepicker/fields.py
@@ -2,7 +2,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import six
 from django.utils.encoding import force_text
-from django.utils.translation import string_concat, gettext_lazy as _
+from django.utils.text import format_lazy, gettext_lazy as _
 
 from .widgets import DateRangeWidget, DateTimeRangeWidget, DatePickerWidget
 
@@ -28,12 +28,12 @@ class DateRangeMixin(object):
             try:
                 beginning = super().to_python(str_dates[0])
             except ValidationError as e:
-                raise ValidationError(string_concat('Error in period beginning: ', e.message), e.code)
+                raise ValidationError(format_lazy('Error in period beginning: {}', e.message), e.code)
 
             try:
                 end = super().to_python(str_dates[1])
             except ValidationError as e:
-                raise ValidationError(string_concat('Error in period end: ', e.message), e.code)
+                raise ValidationError(format_lazy('Error in period end: {}', e.message), e.code)
 
             return beginning, end
         else:

--- a/bootstrap_daterangepicker/widgets.py
+++ b/bootstrap_daterangepicker/widgets.py
@@ -10,7 +10,7 @@ from django.utils import formats
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
-__all__ = ['DateRangeWidget', 'add_month', 'common_dates']
+__all__ = ['DatePickerWidget', 'DateRangeWidget', 'DateTimeRangeWidget', 'add_month', 'common_dates']
 
 format_to_js = {
     '%m': 'MM',
@@ -55,12 +55,12 @@ class DateRangeWidget(forms.TextInput):
 
     def __init__(self, picker_options=None, attrs=None, format=None, separator=' - ', clearable=False):
         super(DateRangeWidget, self).__init__(attrs)
-        
+
         self.separator = separator
         self.format = format
         self.picker_options = picker_options or {}
         self.clearable = clearable
-        
+
         if 'class' not in self.attrs:
             self.attrs['class'] = 'form-control'
 


### PR DESCRIPTION
Fixes #6

_ps. Wish I'd found your fork sooner - I decided to copy the python from` YuriMalinov/django-bootstrap3-daterangepicker` locally and refactor it to fit my needs. My only minor complaint is that you're adding a dependency on `python-dateutil` which I don't use and don't need as I'll supply my own `common_dates` (I use [pendulum](https://pendulum.eustace.io/docs/) in my project)..._