### PR TITLE
Allows you to load jQuery at the end of the body

### DIFF
--- a/bootstrap_daterangepicker/templates/bootstrap_daterangepicker/daterangepicker.html
+++ b/bootstrap_daterangepicker/templates/bootstrap_daterangepicker/daterangepicker.html
@@ -1,6 +1,6 @@
 {% include 'django/forms/widgets/text.html' %}
 <script type="text/javascript">
-    $(function() {
+    window.addEventListener("DOMContentLoaded", function() {
         $('#{{ widget.attrs.id }}').daterangepicker({{ widget.picker.options.json }});
 
 


### PR DESCRIPTION
We defer initialising the daterangepicker until the DOM content has loaded by which point jQuery should have been loaded.