### PR TITLE
If a form field is optional it should be clearable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class DemoForm(forms.Form):
             format='%d/%m/%Y'
         )
     )
-    date_single_clearable = fields.DateField(clearable=True)
+    date_single_clearable = fields.DateField(required=False)
 
     # Date Range Fields
     date_range_normal = fields.DateRangeField()
@@ -38,7 +38,7 @@ class DemoForm(forms.Form):
             format='%d/%m/%Y'
         )
     )
-    date_range_clearable = fields.DateRangeField(clearable=True)
+    date_range_clearable = fields.DateRangeField(required=False)
 
     # DateTime Range Fields
     datetime_range_normal = fields.DateTimeRangeField()
@@ -48,7 +48,7 @@ class DemoForm(forms.Form):
             format='%d/%m/%Y (%I:%M:%S)'
         )
     )
-    datetime_range_clearable = fields.DateTimeRangeField(clearable=True)
+    datetime_range_clearable = fields.DateTimeRangeField(required=False)
 ```
 
 ### Requirements

--- a/bootstrap_daterangepicker/fields.py
+++ b/bootstrap_daterangepicker/fields.py
@@ -36,7 +36,7 @@ class DateRangeMixin(object):
         else:
             raise ValidationError(_("Date range value: " + str(value) + " was not able to be converted to unicode."))
 
-        if self.widget.clearable:
+        if self.widget.clearable():
             if value.strip() == '':
                 return None, None
 
@@ -63,7 +63,7 @@ class DateRangeField(DateRangeMixin, forms.DateField):
 
     def __init__(self, clearable=False, *args, **kwargs):
         super().__init__(type_=date, *args, **kwargs)
-        self.widget.clearable = clearable
+        self.widget.clearable_override = clearable
 
 
 class DateTimeRangeField(DateRangeMixin, forms.DateTimeField):
@@ -71,7 +71,7 @@ class DateTimeRangeField(DateRangeMixin, forms.DateTimeField):
 
     def __init__(self, clearable=False, *args, **kwargs):
         super().__init__(type_=datetime, *args, **kwargs)
-        self.widget.clearable = clearable
+        self.widget.clearable_override = clearable
 
 
 class DateField(forms.DateField):
@@ -79,4 +79,4 @@ class DateField(forms.DateField):
 
     def __init__(self, clearable=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.widget.clearable = clearable
+        self.widget.clearable_override = clearable

--- a/tests/test_date_range.py
+++ b/tests/test_date_range.py
@@ -47,9 +47,7 @@ class DateRangeTests(SimpleTestCase):
 
     def test_not_required_empty(self):
         class TestForm(forms.Form):
-            # FIXME: shouldn't need the clearable param for this test to pass but we currently do
-            # TODO: (also shouldn't need the clearable param at all as can just use the 'required' param)
-            dates = DateRangeField(required=False, clearable=True)
+            dates = DateRangeField(required=False)
 
         form = TestForm({'dates': ''})  # when the form is empty it is actually passed as an empty string
         self.assertTrue(form.is_valid(), msg=form.errors)

--- a/tests/test_date_time_range.py
+++ b/tests/test_date_time_range.py
@@ -50,9 +50,7 @@ class DateTimeRangeTests(SimpleTestCase):
 
     def test_not_required_empty(self):
         class TestForm(forms.Form):
-            # FIXME: shouldn't need the clearable param for this test to pass but we currently do
-            # TODO: (also shouldn't need the clearable param at all as can just use the 'required' param)
-            dates = DateTimeRangeField(required=False, clearable=True)
+            dates = DateTimeRangeField(required=False)
 
         form = TestForm({'dates': ''})  # when the form is empty it is actually passed as an empty string
         self.assertTrue(form.is_valid(), msg=form.errors)


### PR DESCRIPTION
Use the required argument from the form fields as the default for the clearable argument but still overriding clearable if it is passed in for backwards compatibility