### PR TITLE
Catches import error of six in Django 3

### DIFF
--- a/bootstrap_daterangepicker/fields.py
+++ b/bootstrap_daterangepicker/fields.py
@@ -2,7 +2,13 @@ from datetime import date, datetime
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils import six
+
+# Vendored six removed from Django 4.0 (https://bit.ly/2WYMdyW)
+try:
+    from django.utils import six
+except ImportError:
+    import six
+
 from django.utils.encoding import force_text
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _

--- a/bootstrap_daterangepicker/fields.py
+++ b/bootstrap_daterangepicker/fields.py
@@ -2,16 +2,10 @@ from datetime import date, datetime
 
 from django import forms
 from django.core.exceptions import ValidationError
-
-# Vendored six removed from Django 4.0 (https://bit.ly/2WYMdyW)
-try:
-    from django.utils import six
-except ImportError:
-    import six
-
 from django.utils.encoding import force_text
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
+import six
 
 from .widgets import DateRangeWidget, DateTimeRangeWidget, DatePickerWidget
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     packages=['bootstrap_daterangepicker'],
     install_requires=[
         'django',
-        'python-dateutil'
+        'python-dateutil',
+        'six'
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
This package no longer works with Django 3, Im hoping with this fix, it will

Django removed vendored six library, in favor of official one https://bit.ly/2WYMdyW